### PR TITLE
Fixed bug mentioned by reiver/go-porterstemmer#4 by applying mschoch/go-porterstemmer/c5e9efb

### DIFF
--- a/porterstemmer.go
+++ b/porterstemmer.go
@@ -511,8 +511,10 @@ func step5a(s []rune) []rune {
 		m := measure(subSlice)
 		if 1 < m {
 			result = subSlice
-		} else if c := subSlice[len(subSlice)-1]; 1 == m && !(hasConsonantVowelConsonantSuffix(subSlice) && 'w' != c && 'x' != c && 'y' != c) {
-			result = subSlice
+		} else if 1 == m {
+			if c := subSlice[len(subSlice)-1]; !(hasConsonantVowelConsonantSuffix(subSlice) && 'w' != c && 'x' != c && 'y' != c) {
+				result = subSlice
+			}
 		}
 	}
 	return result


### PR DESCRIPTION
This fixes the bug mentioned in reiver/go-porterstemmer#4.
